### PR TITLE
Arrow function on data inject function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const AsyncComputed = {
           this.$options.computed[prefix + key] = get
         })
 
-        this.$options.data = function vueAsyncComputedInjectedDataFn () {
+        this.$options.data = () => {
           const data = (
               (typeof optionData === 'function')
                 ? optionData.call(this)


### PR DESCRIPTION
### Change:
Changed `vueAsyncComputedInjectedDataFn` to arrow function

### Why:
On one of my components I need to "reset" my data state using this code `Object.assign(this.$data, this.$options.data());`, but I get this execption:

```
TypeError: Cannot read property 'asyncComputed' of undefined
    at Object.vueAsyncComputedInjectedDataFn [as data]
```

The `this` on `this.$options.asyncComputed` (line 30) is pointing to the wrong object, changing `vueAsyncComputedInjectedDataFn` to arrow function solves to problem.