### PR TITLE
Add esm module distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.5.0",
   "description": "Async computed properties for Vue",
   "main": "dist/vue-async-computed.js",
+  "module": "dist/vue-async-computed.esm.js",
   "files": [
     "bin/",
     "dist/"
@@ -14,8 +15,9 @@
     "watch": "watch 'npm run build' src test",
     "test": "babel-node --presets env test/index.js | tspec",
     "prebuild": "npm run check -s && npm run clean -s && mkdirp dist",
-    "build": "npm run rollup -s && npm run babel -s",
-    "rollup": "rollup src/index.js --output.format umd --name AsyncComputed --output.file dist/vue-async-computed.esnext.js",
+    "build": "npm run rollup-esm -s && npm run rollup-umd -s && npm run babel -s",
+    "rollup-esm": "rollup src/index.js --output.format esm --name AsyncComputed --output.file dist/vue-async-computed.esm.js",
+    "rollup-umd": "rollup src/index.js --output.format umd --name AsyncComputed --output.file dist/vue-async-computed.esnext.js",
     "babel": "babel --optional runtime dist/vue-async-computed.esnext.js --out-file dist/vue-async-computed.js",
     "postbuild": "npm run test -s",
     "coverage": "node_modules/.bin/babel-node node_modules/.bin/babel-istanbul cover test/index.js",


### PR DESCRIPTION
This adds a new ES module variant with the appropriate "module" definition in package.json so that it can be automatically used by bundlers when appropriate.