### PR TITLE
added vm and info to errorHandler.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ function handleAsyncComputedPropetyChanges (vm, key, pluginOptions, Vue) {
         : pluginOptions.errorHandler
 
       if (pluginOptions.useRawError) {
-        handler(err)
+        handler(err, vm, err.stack)
       } else {
         handler(err.stack)
       }


### PR DESCRIPTION
See https://vuejs.org/v2/api/#errorHandler. The official errorHandler receives 3 parameters: `function (err, vm, info) {}`. I added the vm and info (`err.stack`) to the error handler call.