### PR TITLE
update method can be called after component has been destroyed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,9 @@ function handleAsyncComputedPropetyChanges (vm, key, pluginOptions, Vue) {
   Vue.set(vm.$data._asyncComputed, key, {
     exception: null,
     update: () => {
-      watcher(getterOnly(vm.$options.asyncComputed[key]).apply(vm))
+      if (!vm._isDestroyed){
+        watcher(getterOnly(vm.$options.asyncComputed[key]).apply(vm))
+      }
     }
   })
   setAsyncState(vm, key, 'updating')


### PR DESCRIPTION
It is possible to call the update() method on an asyncComputed property even if the component has been destroyed. One could save a reference to the instance beforehand.

This simple if statement should prevent that behaviour. 
