### PR TITLE
Minor bugfix for watch attribute in asyncComputed types declaration

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,7 +16,7 @@ type AsyncComputedGetter<T> = () => Promise<T>;
 interface IAsyncComputedValue<T> {
   default?: T | (() => T);
   get: AsyncComputedGetter<T>;
-  watch?: () => void;
+  watch?: string[] | (() => void);
   shouldUpdate?: () => boolean;
   lazy?: boolean;
 }


### PR DESCRIPTION
The types declarations seem to work fine by the way, it would be great to get them merged and another release created.