### PR TITLE
Add a decorator for vue-class-component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6389,6 +6389,11 @@
       "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==",
       "dev": true
     },
+    "vue-class-component": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-7.1.0.tgz",
+      "integrity": "sha512-G9152NzUkz0i0xTfhk0Afc8vzdXxDR1pfN4dTwE72cskkgJtdXfrKBkMfGvDuxUh35U500g5Ve4xL8PEGdWeHg=="
+    },
     "watch": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
     "tape": "^4.12.0",
     "vue": "^2.5.21",
     "watch": "^1.0.2"
+  },
+  "dependencies": {
+    "vue-class-component": "^7.1.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import {
   getGetterWithShouldUpdate,
   shouldNotUpdate,
 } from './shouldUpdate'
+import { createDecorator } from 'vue-class-component'
 
 const prefix = '_async_computed$'
 
@@ -176,6 +177,18 @@ function generateDefault (fn, pluginOptions) {
   } else {
     return defaultValue
   }
+}
+
+export function AsyncComputedProp (computedOptions) {
+  return createDecorator((options, key) => {
+    options.asyncComputed = options.asyncComputed || {}
+    const method = options.methods[key]
+    options.asyncComputed[key] = Object.assign(
+      { get: method },
+      computedOptions
+    )
+    delete options.methods[key]
+  })
 }
 
 export default AsyncComputed

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 import Vue, { PluginFunction } from "vue";
+import { VueDecorator } from 'vue-class-component';
 
 export interface IAsyncComputedOptions {
   errorHandler?: (error: string | Error) => void;
@@ -20,6 +21,10 @@ interface IAsyncComputedValue<T> {
   shouldUpdate?: () => boolean;
   lazy?: boolean;
 }
+
+export function AsyncComputedProp<T>(
+  computedOptions?: IAsyncComputedValue<T>,
+): VueDecorator
 
 interface AsyncComputedObject {
   [K: string]: AsyncComputedGetter<any> | IAsyncComputedValue<any>;


### PR DESCRIPTION
Made a decorator for [vue-class-component](https://github.com/vuejs/vue-class-component)

The implementation is based on <https://github.com/foxbenjaminfox/vue-async-computed/issues/25#issuecomment-459369072>. Thank you very much @saraedum and @TheNoim!

Here is a usage.
```ts
import { AsyncComputedProp } from "vue-async-computed";

...

  @AsyncComputedProp()
  private async myText(): Promise<string> {
    ...
  }
...
```

I'd like to use `@AsyncComputed()` instead of `@AsyncComputedProp()`, but `AsyncComputed` is already defined in the scope. Does someone have a better name than `@AsyncComputedProp` ?