### PR TITLE
Separated IAsyncComputedValueBase<T> from IAsyncComputedValue<T>

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,12 +14,15 @@ export default class AsyncComputed {
 
 export type AsyncComputedGetter<T> = () => Promise<T>;
 
-export interface IAsyncComputedValue<T> {
+export interface IAsyncComputedValueBase<T> {
   default?: T | (() => T);
-  get: AsyncComputedGetter<T>;
   watch?: string[] | (() => void);
   shouldUpdate?: () => boolean;
   lazy?: boolean;
+}
+
+export interface IAsyncComputedValue<T> extends IAsyncComputedValueBase<T> {
+  get: AsyncComputedGetter<T>;
 }
 
 export interface AsyncComputedObject {


### PR DESCRIPTION
Hey,
I just separated the `get`  property from the rest of the `IAsyncComputedValue<T>` interface as discussed [here](https://github.com/foxbenjaminfox/vue-async-computed-decorator/pull/6).

Since there is already a `IAsyncComputedOptions` declaration, I decided to put everything into the `IAsyncComputedValueBase<T>` interface. This should not introduce any breaking changes.