### PR TITLE
Default values applied before watch/computed can read undefined/null value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ const AsyncComputed = {
           this.$options.computed[prefix + key] = getter
         }
 
-        this.$options.data = initDataWithAsyncComputed(this.$options)
+        this.$options.data = initDataWithAsyncComputed(this.$options, pluginOptions)
       },
       created () {
         for (const key in this.$options.asyncComputed || {}) {
@@ -115,7 +115,7 @@ function handleAsyncComputedPropetyChanges (vm, key, pluginOptions, Vue) {
   vm.$watch(prefix + key, watcher, { immediate: true })
 }
 
-function initDataWithAsyncComputed (options) {
+function initDataWithAsyncComputed (options, pluginOptions) {
   const optionData = options.data
   const asyncComputed = options.asyncComputed || {}
 
@@ -125,11 +125,13 @@ function initDataWithAsyncComputed (options) {
       : optionData) || {}
     for (const key in asyncComputed) {
       const item = this.$options.asyncComputed[key]
+
+      var value = generateDefault.call(this, item, pluginOptions)
       if (isComputedLazy(item)) {
-        initLazy(data, key)
+        initLazy(data, key, value)
         this.$options.computed[key] = makeLazyComputed(key)
       } else {
-        data[key] = null
+        data[key] = value
       }
     }
     return data

--- a/src/lazy.js
+++ b/src/lazy.js
@@ -11,9 +11,9 @@ export function isLazyActive (vm, key) {
 const lazyActivePrefix = 'async_computed$lazy_active$',
       lazyDataPrefix = 'async_computed$lazy_data$'
 
-export function initLazy (data, key) {
+export function initLazy (data, key, value) {
   data[lazyActivePrefix + key] = false
-  data[lazyDataPrefix + key] = null
+  data[lazyDataPrefix + key] = value
 }
 
 export function makeLazyComputed (key) {

--- a/test/index.js
+++ b/test/index.js
@@ -221,7 +221,7 @@ test("Multiple asyncComputed objects are handled the same as normal computed pro
 })
 
 test("Async computed values can have defaults", t => {
-  t.plan(6)
+  t.plan(8)
   const vm = new Vue({
     asyncComputed: {
       x: {
@@ -238,9 +238,27 @@ test("Async computed values can have defaults", t => {
           return Promise.resolve(true)
         }
       }
-    }
+    },
+    watch: {
+      x: {
+        deep: true,
+        immediate: true,
+        handler (newValue, oldValue) {
+          if (oldValue === undefined) {
+            t.equal(newValue, false, 'watch: x should default to false')
+          }
+        }
+      },
+    },
+    computed: {
+      computedFromX: function () {
+        t.equal(this.x, false, 'computed: x should default to false')
+        return this.x
+      },
+    },
   })
-  t.equal(vm.x, false, 'x should default to true')
+  const computed = vm.computedFromX// Force computed execution
+  t.equal(vm.x, false, 'x should default to false')
   t.equal(vm.y, null, 'y doesn\'t have a default')
   t.equal(vm.z, null, 'z doesn\'t have a default despite being defined with an object')
   Vue.nextTick(() => {


### PR DESCRIPTION
closes https://github.com/foxbenjaminfox/vue-async-computed/issues/74

Set default values in beforeCreate event so they are non-null for watch & computed functions.
Added tests for state of default values in watch & computed functions.