### PR TITLE
improve types to allow access like computed

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
-import Vue, { PluginFunction } from 'vue';
+import { PluginFunction } from 'vue';
+import { ComponentOptions, DataDef, RecordPropsDefinition } from 'vue/types/options';
 
 export interface IAsyncComputedOptions {
   errorHandler?: (error: string | Error) => void;
@@ -25,10 +26,6 @@ export interface IAsyncComputedValue<T> extends IAsyncComputedValueBase<T> {
   get: AsyncComputedGetter<T>;
 }
 
-export interface AsyncComputedObject {
-  [K: string]: AsyncComputedGetter<any> | IAsyncComputedValue<any>;
-}
-
 export interface IASyncComputedState {
   state: 'updating' | 'success' | 'error';
   updating: boolean;
@@ -38,14 +35,33 @@ export interface IASyncComputedState {
   update: () => void;
 }
 
-declare module 'vue/types/options' {
-  interface ComponentOptions<V extends Vue> {
-    asyncComputed?: AsyncComputedObject;
-  }
+
+export type AsyncComputedObject <T> = {
+  [K in keyof T] : AsyncComputedGetter<T[K]> | IAsyncComputedValue<T[K]>;
+}
+
+export type AsyncComputedStates<T> = {
+  $asyncComputed: {[K in keyof T]: IASyncComputedState};
+}
+
+export interface AsyncComputedOption <T> {
+  asyncComputed?: AsyncComputedObject<T>;
 }
 
 declare module 'vue/types/vue' {
-  interface Vue {
-    $asyncComputed: {[K: string]: IASyncComputedState};
+  interface VueConstructor<V extends Vue = Vue> {
+    extend<Data, Methods, Computed, PropNames extends string = never, AsyncComputed = {}>(options?:
+      object &
+      ComponentOptions<V, DataDef<Data, Record<PropNames, any>, V>, Methods, Computed, PropNames[], Record<PropNames, any>> &
+      AsyncComputedOption<AsyncComputed> &
+      ThisType<CombinedVueInstance<V, Data, Methods, Computed & AsyncComputed & AsyncComputedStates<AsyncComputed>, Readonly<Record<PropNames, any>>>>
+    ): ExtendedVue<V, Data, Methods, Computed & AsyncComputed & AsyncComputedStates<AsyncComputed>, Record<PropNames, any>>;
+
+    extend<Data, Methods, Computed, Props, AsyncComputed = {}>(options?:
+      object &
+      ComponentOptions<V, DataDef<Data, Props, V>, Methods, Computed, RecordPropsDefinition<Props>, Props> &
+      AsyncComputedOption<AsyncComputed> &
+      ThisType<CombinedVueInstance<V, Data, Methods, Computed & AsyncComputed & AsyncComputedStates<AsyncComputed>, Readonly<Props>>>
+    ): ExtendedVue<V, Data, Methods, Computed & AsyncComputed & AsyncComputedStates<AsyncComputed>, Props>;
   }
 }


### PR DESCRIPTION
With this PR, async computed values can be accessed without type error, just like computed values.
Even more, `this.$asyncComputed.` is also properly typed.