### PR TITLE
Fix `AsyncComputed` type.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import Vue, { PluginFunction } from 'vue';
+import Vue, { PluginFunction, PluginObject } from 'vue';
 
 export interface IAsyncComputedOptions {
   errorHandler?: (error: string | Error) => void;
@@ -6,9 +6,9 @@ export interface IAsyncComputedOptions {
   default?: any;
 }
 
-export default class AsyncComputed {
+export default class AsyncComputed extends PluginObject<void> {
   constructor(options?: IAsyncComputedOptions);
-  static install: PluginFunction<never>;
+  static install: PluginFunction<void>;
   static version: string;
 }
 


### PR DESCRIPTION
`PluginFunction<never>` should be `PluginFunction<void>`, otherwise the following code will not satisfy TS checks:

```ts
import Vue from "vue";
import AsyncComputed from "vue-async-computed";
Vue.use(AsyncComputed, {})
```

![image](https://user-images.githubusercontent.com/10025342/135603473-c14a29fd-70b3-4c5a-b70b-83008235c98c.png)

`never` means "this function **never** returns", while `void` means "this function **always** returns **undefined**"