### PR TITLE
Include name of AsyncComputed property in error message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ function handleAsyncComputedPropetyChanges (vm, key, pluginOptions) {
       if (pluginOptions.errorHandler === false) return
 
       const handler = (pluginOptions.errorHandler === undefined)
-        ? console.error.bind(console, 'Error evaluating async computed property:')
+        ? console.error.bind(console, 'Error evaluating async computed property', '"' + vm.$options.name + '.' + key + '":')
         : pluginOptions.errorHandler
 
       if (pluginOptions.useRawError) {


### PR DESCRIPTION
Make debugging of errors in async-computed properties more easy by mentioning which component + property the error was thrown in.

```bash
#before
Error evaluating async computed property: <some error message>

#after
Error evaluating async computed property "UserProfileComponent.profileData": <some error message>

```

I needed this to debug an async-computed exception, and I couldn't figure out what was throwing it due to complex reactivity, and async call-stacks.

Hope you find it useful and are willing to include it.